### PR TITLE
Modify the check for minimum store operational days to two

### DIFF
--- a/amazon-hub-counter-openapi.yaml
+++ b/amazon-hub-counter-openapi.yaml
@@ -1198,7 +1198,7 @@ components:
         standardHours:
           type: array
           description: 'Array containing location standard opening hours.'
-          minItems: 1
+          minItems: 2
           items:
             type: object
             properties:


### PR DESCRIPTION
This change modifies the minItems constraint in the store_schema JSON object for standardHours from 1 (one) to 2 (two).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
