### PR TITLE
Remove noOfAccessPointsSuccessfullyProcessedWithWarnings field 

### DIFF
--- a/amazon-hub-counter-openapi.yaml
+++ b/amazon-hub-counter-openapi.yaml
@@ -1677,10 +1677,6 @@ components:
           example: 1
           description: 'Total number of Access Points unable to process due to errors.'
           type: integer
-        noOfAccessPointSuccessfullyProcessedWithWarnings:
-          type: integer
-          example: 1
-          description: Total number of Access Points successfully updated with some warnings regarding the updates.
         failedAccessPointProcessingDetails:
           type: array
           description: Detailed list of errors for this feed.


### PR DESCRIPTION
We are removing the (optional) field noOfAccessPointsSuccessfullyProcessedWithWarnings from the OutputDocument, since it was misleading. The number of stores with warnings will be included in the noOfAccessPointsSuccessfullyProcessed, since warnings don't prevent the stores from being processed. We are keeping the field warningDetails, which provide details which stores have warnings for your visibility.

*Issue #, if available:*

*Description of changes:*
Removing noOfAccessPointSuccessfullyProcessedWithWarnings in OutputDocument

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
