### PR TITLE
Update amazon-hub-counter-openapi.yaml with JP translated accesspoint…

### DIFF
--- a/amazon-hub-counter-openapi.yaml
+++ b/amazon-hub-counter-openapi.yaml
@@ -1207,7 +1207,7 @@ components:
           example: 'Amazon Counter - Acme Manchester'
           maximum: 50
           description: |
-            Customer-facing business name for location, prepended by the fixed string `Amazon Counter - `. 
+            Customer-facing business name for location, prepended by the fixed string `Amazon Counter - ` or `Amazon カウンター -` for JP. 
             
             If location descriptor is used to differentiate store chains, add it after the store name. 
             


### PR DESCRIPTION
Update amazon-hub-counter-openapi.yaml with JP translated accesspointName prefix

*Issue #, if available:*

*Description of changes:*
An update to the documentation to cover the JP accesspointName translated prefix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
